### PR TITLE
Add CLI args for API key and files destination path

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -37,6 +37,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "assert_cmd"
+version = "2.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93ae1ddd39efd67689deb1979d80bad3bf7f2b09c6e6117c8d1f2443b5e2f83e"
+dependencies = [
+ "bstr",
+ "doc-comment",
+ "predicates",
+ "predicates-core",
+ "predicates-tree",
+ "wait-timeout",
+]
+
+[[package]]
 name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -64,6 +78,17 @@ name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "bstr"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba3569f383e8f1598449f1a423e72e99569137b47740b1da11ef19af3d5c3223"
+dependencies = [
+ "lazy_static",
+ "memchr",
+ "regex-automata",
+]
 
 [[package]]
 name = "bumpalo"
@@ -176,6 +201,12 @@ name = "difflib"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
+
+[[package]]
+name = "doc-comment"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
 
 [[package]]
 name = "downcast"
@@ -853,6 +884,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex-automata"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
+
+[[package]]
 name = "regex-syntax"
 version = "0.6.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -912,9 +949,10 @@ checksum = "f3f6f92acf49d1b98f7a81226834412ada05458b7364277387724a237f062695"
 
 [[package]]
 name = "scancli"
-version = "1.2.0"
+version = "1.3.0"
 dependencies = [
  "anyhow",
+ "assert_cmd",
  "clap",
  "log",
  "mockall",
@@ -1207,6 +1245,15 @@ name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
+
+[[package]]
+name = "wait-timeout"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f200f5b12eb75f8c1ed65abd4b2db8a6e1b138a20de009dacee265a2498f3f6"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "want"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,13 +8,14 @@ description = "A CLI app to interact with any etherscan.io compatible API"
 
 [dependencies]
 anyhow = "1.0"
-clap = { version = "3.2", features = ["derive"] }
+clap = { version = "3.2", features = ["derive", "env"] }
 log = "0.4"
 reqwest = { version = "0.11", features = ["blocking", "json"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 
 [dev-dependencies]
+assert_cmd = "2.0"
 mockall = "0.11"
 mockito = "0.31"
 pretty_assertions = "1.2"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,7 +8,12 @@ use contracts::service::Contracts;
 
 pub const CONTRACTS_DEST_DIR: &str = "./contracts";
 
-pub fn go(api_key: String, api_url: String, contract_address: String) -> Result<()> {
+pub fn go(
+    api_key: String,
+    api_url: String,
+    contract_address: String,
+    files_dest_path: String,
+) -> Result<()> {
     let http_client = reqwest::blocking::Client::new();
 
     let contracts_client = contracts::client::Client::new(api_key, api_url, http_client);
@@ -49,7 +54,7 @@ pub fn go(api_key: String, api_url: String, contract_address: String) -> Result<
             ));
         }
 
-        let contract_dir = Path::new(CONTRACTS_DEST_DIR)
+        let contract_dir = Path::new(&files_dest_path)
             .join(&contract_address)
             .join(p.parent().unwrap());
         fs::create_dir_all(&contract_dir).context("failed to create contracts dir")?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,16 +1,16 @@
-use anyhow::{Context, Result};
+use anyhow::Result;
 use clap::Parser;
 use log::info;
-use std::fs;
 
 #[derive(Parser)]
 struct Args {
-    #[clap(default_value = "./etherscan-api-key.txt", long, short = 'k')]
-    api_key_file_path: String,
+    #[clap(env = "SCAN_API_KEY", long, short = 'k')]
+    api_key: String,
     #[clap(default_value = "https://api.etherscan.io", long, short = 'u')]
     api_url: String,
-    #[clap(long, short = 'a')]
     contract_address: String,
+    #[clap(default_value = "./contracts", long, short = 'd')]
+    files_dest_path: String,
 }
 
 fn main() -> Result<()> {
@@ -18,8 +18,10 @@ fn main() -> Result<()> {
 
     let args = Args::parse();
 
-    let api_key =
-        fs::read_to_string(&args.api_key_file_path).context("failed to read API key file")?;
-
-    scancli::go(api_key, args.api_url, args.contract_address)
+    scancli::go(
+        args.api_key,
+        args.api_url,
+        args.contract_address,
+        args.files_dest_path,
+    )
 }


### PR DESCRIPTION
perf(#6): Add CLI args for API key and files destination path, rename integration test and change it to run the binary from CLI instead of calling lib function.
