### PR TITLE
gh 28/cli version

### DIFF
--- a/.github/workflows/test-build-release.yaml
+++ b/.github/workflows/test-build-release.yaml
@@ -22,20 +22,23 @@ jobs:
           command: test
           args: --release --target=x86_64-unknown-linux-musl
           use-cross: true
+      - name: Install semantic-release and toml-cli
+        run: |
+          npm install --save-dev \
+            semantic-release \
+            @semantic-release/changelog \
+            @semantic-release/git \
+              && pip3 install toml-cli
+      - name: Get next release tag and update Cargo.toml
+        run: |
+          next_release_version=$(npx semantic-release --dry-run | grep --only-matching --perl-regexp 'Published release \K(\d|\.)+')
+          toml set --toml-path Cargo.toml package.version "${next_release_version}" && cargo check
       - name: Build Linux x86_64 release binary
         uses: actions-rs/cargo@v1
         with:
           command: build
           args: --release --target=x86_64-unknown-linux-musl
           use-cross: true
-      - name: Install semantic-release and toml-cli
-        run: |
-          npm install --save-dev \
-            semantic-release \
-            @semantic-release/changelog \
-            @semantic-release/exec \
-            @semantic-release/git \
-              && pip3 install toml-cli
       - name: Release it!
         env:
           GH_TOKEN: ${{ secrets.GH_TOKEN }}

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -7,12 +7,6 @@
     "@semantic-release/release-notes-generator",
     "@semantic-release/changelog",
     [
-      "@semantic-release/exec",
-      {
-        "prepareCmd": "toml set --toml-path Cargo.toml package.version ${nextRelease.version} && cargo check"
-      }
-    ],
-    [
       "@semantic-release/git",
       {
         "assets": [

--- a/README.md
+++ b/README.md
@@ -15,8 +15,11 @@ issue.
 
 ### Download
 
+Check the Releases page for latest stable version and update `ETHERSCAN_VERSION` env var below.
+
 ```bash
-curl -LO https://github.com/dragossutu/etherscan/releases/download/1.9.0/etherscan-linux-amd64-1.9.0 -o etherscan \
+ETHERSCAN_VERSION="1.11.0" \
+  && curl -L -o etherscan "https://github.com/dragossutu/etherscan/releases/download/${ETHERSCAN_VERSION}/etherscan-linux-amd64-${ETHERSCAN_VERSION}" \
   && chmod +x etherscan \
   && sudo mv etherscan /usr/local/bin
 ```
@@ -34,8 +37,7 @@ cargo build --release
 
 1. Create an API key for the block explorer you want to use the CLI for. (requires an account)
 
-2. (Optional) Export the API key as an environment variable ETHERSCAN_API_KEY.
-Can be passed as CLI flag outherwise
+2. Export the API key as an environment variable `ETHERSCAN_API_KEY` or pass it as a CLI flag:
 ```bash
 export ETHERSCAN_API_KEY=your_api_key_here
 ```


### PR DESCRIPTION
- fix(gh-28): Get next release, using semantic-release, before building binary. Update version in Cargo files from pipeline instead of using semantic-release exec plugin
- fix(gh-28): Fix install command in docs
