### PR TITLE
refactor(`files`): build the contract name in a more idiomatic way

### DIFF
--- a/src/files.rs
+++ b/src/files.rs
@@ -61,17 +61,11 @@ impl Files for Service {
                 ));
             }
 
-            let mut contract_dir_name_builder;
-            if folder_prefix.is_empty() {
-                contract_dir_name_builder = String::from(&contract.name);
+            let contract_dir_name_builder = if folder_prefix.is_empty() {
+                format!("{}-{}", contract.name, contract_address)
             } else {
-                contract_dir_name_builder = String::from(folder_prefix);
-                contract_dir_name_builder.push('-');
-                contract_dir_name_builder.push_str(&contract.name);
-            }
-
-            contract_dir_name_builder.push('-');
-            contract_dir_name_builder.push_str(contract_address);
+                format!("{}-{}-{}", folder_prefix, contract.name, contract_address)
+            };
 
             let contract_path = Path::new(files_dest_path)
                 .join(network_name)


### PR DESCRIPTION
Cool project! Just had a little read through it and saw that the contract dir name could be built in a more idiomatic way. It uses the `format!` macro to build the string, and combines two blocks of logic into one, removing the need for making the variable `mut`.

No pressure to accept this PR/make changes if it's not what you have in mind!

I've ran the tests + clippy to make sure nothing's broken.